### PR TITLE
Returns error if one occurs when walking the dir

### DIFF
--- a/impl/s3/s3.go
+++ b/impl/s3/s3.go
@@ -90,6 +90,10 @@ func (m *Minio) PopulateFn(addr, source, prefix string, timeout int64) error {
 	m.StartPopulate(prefix, currentTime)
 	manifest := Manifest{}
 	err := fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+		  	return err
+		}
+
 		if d.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
> If a directory read fails, the function is called a second time for that directory to report the error.

https://pkg.go.dev/io/fs#WalkDirFunc